### PR TITLE
fix: change absolute to relative import

### DIFF
--- a/routingpy/valhalla_attributes.py
+++ b/routingpy/valhalla_attributes.py
@@ -18,7 +18,7 @@
 from enum import Enum
 from typing import List, Optional, Tuple, Union
 
-from routingpy.utils import decode_polyline6
+from .utils import decode_polyline6
 
 
 class MatchDiscontinuity(str, Enum):


### PR DESCRIPTION
Absolute imports of our own package is not nice :sweat_smile: Breaks e.g. for submodules without fiddling with PYTHONPATH crap..