### PR TITLE
fix(openrouteservice): handle empty summary for identical source/destination points

### DIFF
--- a/routingpy/routers/openrouteservice.py
+++ b/routingpy/routers/openrouteservice.py
@@ -323,8 +323,16 @@ class ORS:
                     routes.append(
                         Direction(
                             geometry=route["geometry"]["coordinates"],
-                            distance=int(route["properties"]["summary"]["distance"]),
-                            duration=int(route["properties"]["summary"]["duration"]),
+                            distance=(
+                                int(route["properties"]["summary"]["distance"])
+                                if route["properties"]["summary"]
+                                else 0
+                            ),
+                            duration=(
+                                int(route["properties"]["summary"]["duration"])
+                                if route["properties"]["summary"]
+                                else 0
+                            ),
                             raw=route,
                         )
                     )


### PR DESCRIPTION
Fixes KeyError when ORS returns empty summary for directions with same or very close source/destination points by defaulting distance and duration to 0. 
This resolves #158 